### PR TITLE
Increase height threshold for Menu Bar Icon check

### DIFF
--- a/WooshyWindowToTheForeground/Menus/Entrance.swift
+++ b/WooshyWindowToTheForeground/Menus/Entrance.swift
@@ -194,7 +194,7 @@ extension Entrance {
     }
         
     private static func visibleWindowIsNotAMenuBarIcon(layer: Int, height: Double) -> Bool {
-        layer != 25 || height > 24
+        layer != 25 || height > 37 // Prevents the menu bar icons from showing up on Macbooks with notch
     }
     
     private static func removeCurrentlyFocusedWindow(from visibleWindows: [Window]) -> [Window] {


### PR DESCRIPTION
Checking against `height > 37` prevents the menu bar icons from showing up on Macbooks with notch